### PR TITLE
Bugfixes handling of MatchingRequestParameter in response-prefixes

### DIFF
--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -321,8 +321,9 @@ class DiagLayer:
             # Compute prefixes for the request and all responses
             request_prefix = s.request.coded_const_prefix()
             prefixes = [request_prefix] + [
-                message.coded_const_prefix(request_prefix=request_prefix) for message in chain(s.positive_responses,
-                                                                                               s.negative_responses)
+                message.coded_const_prefix(
+                    request_prefix=request_prefix
+                ) for message in chain(s.positive_responses, s.negative_responses)
             ]
             for coded_prefix in prefixes:
                 # Traverse prefix tree

--- a/odxtools/service.py
+++ b/odxtools/service.py
@@ -107,7 +107,8 @@ class DiagService:
 
         # Check if message is a request or positive or negative response
         interpretable_message_types = list(filter(lambda r: all(b == message[i]
-                                                                for (i, b) in enumerate(r.coded_const_prefix())),
+                                                                for (i, b) in enumerate(r.coded_const_prefix(
+                                                                    request_prefix=self.request.coded_const_prefix()))),
                                                   [self.request, *self.positive_responses,
                                                    *self.negative_responses]
                                                   ))

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -34,9 +34,12 @@ class BasicStructure(DopBase):
 
     def coded_const_prefix(self, request_prefix: Union[bytes, bytearray] = bytes()):
         prefix = bytearray()
-        encode_state = EncodeState(prefix, parameter_values={})
+        encode_state = EncodeState(prefix, parameter_values={}, triggering_request=request_prefix)
         for p in self.parameters:
             if isinstance(p, CodedConstParameter) and p.bit_length % 8 == 0:
+                prefix = p.encode_into_pdu(encode_state)
+                encode_state = EncodeState(prefix, *encode_state[1:])
+            elif isinstance(p, MatchingRequestParameter):
                 prefix = p.encode_into_pdu(encode_state)
                 encode_state = EncodeState(prefix, *encode_state[1:])
             else:


### PR DESCRIPTION
When a positive or negative response used MatchingRequestParameter,
the parameter was ignored, and the resulting calculated prefixes
for the responses were incomplete.

This caused the wrong service to be matched when using find
for a response in these cases (e.g. if a RecordDataIdentifier
was used for a ReadDataByIdentifier-response)