### PR TITLE
Add PhysicalType and rework handling of data types

### DIFF
--- a/examples/somersaultecu.py
+++ b/examples/somersaultecu.py
@@ -27,6 +27,7 @@ from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.diagdatadictionaryspec import DiagDataDictionarySpec
 
 from odxtools.diagcodedtypes import StandardLengthType
+from odxtools.physicaltype import PhysicalType
 
 from odxtools.units import UnitSpec
 from odxtools.units import PhysicalDimension
@@ -191,7 +192,7 @@ somersault_dops = {
         id="somersault.DOP.num_flips",
         short_name="num_flips",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
-        physical_data_type="A_UINT32",
+        physical_type=PhysicalType("A_UINT32"),
         compu_method=somersault_compumethods["uint_passthrough"]),
 
     "soberness_check":
@@ -199,7 +200,7 @@ somersault_dops = {
         id="somersault.DOP.soberness_check",
         short_name="soberness_check",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
-        physical_data_type="A_UINT32",
+        physical_type=PhysicalType("A_UINT32"),
         compu_method=somersault_compumethods["uint_passthrough"]),
 
     "dizzyness_level":
@@ -207,7 +208,7 @@ somersault_dops = {
         id="somersault.DOP.dizzyness_level",
         short_name="dizzyness_level",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
-        physical_data_type="A_UINT32",
+        physical_type=PhysicalType("A_UINT32"),
         compu_method=somersault_compumethods["uint_passthrough"]),
 
     "happiness_level":
@@ -215,7 +216,7 @@ somersault_dops = {
         id="somersault.DOP.happiness_level",
         short_name="happiness_level",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
-        physical_data_type="A_UINT32",
+        physical_type=PhysicalType("A_UINT32"),
         compu_method=somersault_compumethods["uint_passthrough"]),
 
     "duration":
@@ -223,7 +224,7 @@ somersault_dops = {
         id="somersault.DOP.duration",
         short_name="duration",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
-        physical_data_type="A_UINT32",
+        physical_type=PhysicalType("A_UINT32"),
         compu_method=somersault_compumethods["uint_passthrough"],
         unit_ref=somersault_units["second"].id),
 
@@ -232,7 +233,7 @@ somersault_dops = {
         id="somersault.DOP.error_code",
         short_name="error_code",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
-        physical_data_type="A_UINT32",
+        physical_type=PhysicalType("A_UINT32"),
         compu_method=somersault_compumethods["uint_passthrough"]),
 
     "boolean":
@@ -240,7 +241,7 @@ somersault_dops = {
         id="somersault.DOP.boolean",
         short_name="boolean",
         diag_coded_type=somersault_diagcodedtypes["uint8"],
-        physical_data_type="A_UNICODE2STRING",
+        physical_type=PhysicalType("A_UNICODE2STRING"),
         compu_method=somersault_compumethods["boolean"]),
 }
 

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -16,7 +16,7 @@ from .functionalclass import read_functional_class_from_odx
 from .audience import read_additional_audience_from_odx
 from .message import Message
 from .service import DiagService, read_diag_service_from_odx
-from .structures import Request, Response, Structure, read_structure_from_odx
+from .structures import Request, Response, read_structure_from_odx
 
 # Defines priority of overiding objects
 PRIORITY_OF_DIAG_LAYER_TYPE = {

--- a/odxtools/pdx_stub/macros/printDOP.tpl
+++ b/odxtools/pdx_stub/macros/printDOP.tpl
@@ -5,7 +5,7 @@
 -#}
 
 {%- macro printDiagCodedType(dct) -%}
-<DIAG-CODED-TYPE BASE-DATA-TYPE="{{dct.base_data_type}}"
+<DIAG-CODED-TYPE BASE-DATA-TYPE="{{dct.base_data_type.value}}"
  {%- filter odxtools_collapse_xml_attribute %}
   {%- if dct.base_type_encoding %}
                  BASE-TYPE-ENCODING="{{dct.base_type_encoding}}"
@@ -35,6 +35,18 @@
 </DIAG-CODED-TYPE>
 {%- endmacro -%}
 
+
+{%- macro printPhysicalType(physical_type) %}
+{%- if physical_type.display_radix is not none %}
+<PHYSICAL-TYPE BASE-DATA-TYPE="{{physical_type.base_data_type.value}}" DISPLAY-RADIX="{{physical_type.display_radix.value}}" />
+{%- elif physical_type.precision is not none   %}
+<PHYSICAL-TYPE BASE-DATA-TYPE="{{physical_type.base_data_type.value}}">
+ <PRECISION>{{physical_type.precision}}</PRECISION>
+</PHYSICAL-TYPE>
+{%- else %}
+<PHYSICAL-TYPE BASE-DATA-TYPE="{{physical_type.base_data_type.value}}" />
+{%- endif %}
+{%- endmacro -%}
 
 
 {%- macro printCompuMethod(cm) -%}
@@ -128,8 +140,6 @@
 {%- endmacro -%}
 
 
-
-
 {%- macro printDOP(dop, tag_name) %}
 <{{tag_name}} ID="{{dop.id}}">
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
@@ -139,14 +149,8 @@
 {%- endif %}
 {%- if dop.diag_coded_type is defined %}
  {{ printDiagCodedType(dop.diag_coded_type)|indent(1) -}}
-{%- endif %}
-{%- if dop.physical_data_type.startswith("A_UINT")   %}
- <PHYSICAL-TYPE BASE-DATA-TYPE="{{dop.physical_data_type}}" DISPLAY-RADIX="HEX" />
-{%- elif dop.physical_data_type.startswith("A_INT")   %}
- <PHYSICAL-TYPE BASE-DATA-TYPE="{{dop.physical_data_type}}" DISPLAY-RADIX="DEC" />
-{%- else %}
- <PHYSICAL-TYPE BASE-DATA-TYPE="{{dop.physical_data_type}}" />
-{%- endif %}
+{%- endif -%}
+ {{ printPhysicalType(dop.physical_type)|indent(1) }}
 {%- if dop.unit_ref %}
  <UNIT-REF ID-REF="{{ dop.unit_ref }}" />
 {%- endif %}
@@ -159,13 +163,7 @@
  <SHORT-NAME>{{dop.short_name}}</SHORT-NAME>
  <LONG-NAME>{{dop.long_name}}</LONG-NAME>
  {{ printDiagCodedType(dop.diag_coded_type)|indent(1) -}}
-{%- if dop.physical_data_type.startswith("A_UINT")   %}
- <PHYSICAL-TYPE BASE-DATA-TYPE="{{dop.physical_data_type}}" DISPLAY-RADIX="HEX" />
-{%- elif dop.physical_data_type.startswith("A_INT")   %}
- <PHYSICAL-TYPE BASE-DATA-TYPE="{{dop.physical_data_type}}" DISPLAY-RADIX="DEC" />
-{%- else %}
- <PHYSICAL-TYPE BASE-DATA-TYPE="{{dop.physical_data_type}}" />
-{%- endif %}
+ {{ printPhysicalType(dop.physical_type)|indent(1) }}
  {{ printCompuMethod(dop.compu_method)|indent(1) }}
  <DTCS>
  {%- for dtc in dop.dtcs %}

--- a/odxtools/pdx_stub/macros/printVariant.tpl
+++ b/odxtools/pdx_stub/macros/printVariant.tpl
@@ -38,7 +38,7 @@
  <DIAG-DATA-DICTIONARY-SPEC>
 {%- if dl.local_diag_data_dictionary_spec.dtc_dops  %}
   <DTC-DOPS>
- {%- for dop in dl.local_diag_data_dictionary_spec.dtc_dops %}
+ {%- for dop in dl.local_diag_data_dictionary_spec.dtc_dops -%}
   {{ pdop.printDTCDOP(dop)|indent(3) }}
  {%- endfor %}
   </DTC-DOPS>

--- a/odxtools/physicaltype.py
+++ b/odxtools/physicaltype.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 MBition GmbH
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from .odxtypes import DataType
+
+
+class Radix(Enum):
+    HEX = "HEX"
+    DEC = "DEC"
+    BIN = "BIN"
+    OCT = "OCT"
+
+
+@dataclass
+class PhysicalType:
+    """The physical type describes the base data type of a parameter.
+
+    Similar to how a `DiagCodedType` describes the encoding of the internal value,
+    the `PhysicalType` describes how to display the physical value.
+
+    For an unsigned integers (A_UINT32) it may specify a display radix (HEX, DEC, BIN, OCT).
+    For floating point numbers (A_FLOAT32, A_FLOAT64) it may specify a precision,
+    that is, the number of digits to display after the decimal point.
+
+    Examples
+    --------
+
+    A hexadecimal, integer number::
+
+    PhysicalType(DataType.A_UINT32, display_radix=Radix.HEX)
+
+    A floating point number that should be displayed with 2 digits after the decimal point::
+
+    PhysicalType(DataType.A_FLOAT64, precision=2)
+    """
+
+    base_data_type: DataType
+
+    display_radix: Optional[Radix] = None
+    """The display radix defines how integers are displayed to the user.
+    The display radix is only applicable if the base data type is A_UINT32. 
+    """
+
+    precision: Optional[int] = None
+    """Number of digits after the decimal point to display to the user
+    The precision is only applicable if the base data type is A_FLOAT32 or A_FLOAT64. 
+    """
+
+    def __post_init__(self):
+        self.base_data_type = DataType(self.base_data_type)
+        if self.display_radix is not None:
+            self.display_radix = Radix(self.display_radix)
+
+
+def read_physical_type_from_odx(et_element):
+    base_data_type = et_element.get("BASE-DATA-TYPE")
+    assert base_data_type in ["A_INT32", "A_UINT32", "A_FLOAT32", "A_FLOAT64",
+                              "A_ASCIISTRING", "A_UTF8STRING", "A_UNICODE2STRING", "A_BYTEFIELD"]
+    display_radix = et_element.get("DISPLAY-RADIX")
+    precision = et_element.findtext("PRECISION")
+    if precision is not None:
+        precision = int(precision)
+
+    return PhysicalType(base_data_type,
+                        display_radix=display_radix,
+                        precision=precision)

--- a/tests/test_compu_methods.py
+++ b/tests/test_compu_methods.py
@@ -68,7 +68,7 @@ class TestLinearCompuMethod(unittest.TestCase):
         self.assertEqual(compu_method.convert_physical_to_internal(21), 4)
 
     def test_linear_compu_method_physical_limits(self):
-        # Define decoding function: f: (2, 15] -> [-74, -9), f(x) = -5*x + 1
+        # Define decoding function: f: (2, 15] -> [-74, -14], f(x) = -5*x + 1
         compu_method = LinearCompuMethod(1, -5, "A_INT32", "A_INT32",
                                          internal_lower_limit=Limit(2,
                                                                     interval_type=IntervalType.OPEN),
@@ -77,7 +77,7 @@ class TestLinearCompuMethod(unittest.TestCase):
         self.assertEqual(compu_method.physical_lower_limit,
                          Limit(-74, interval_type=IntervalType.CLOSED))
         self.assertEqual(compu_method.physical_upper_limit,
-                         Limit(-9, interval_type=IntervalType.OPEN))
+                         Limit(-14, interval_type=IntervalType.CLOSED))
 
         self.assertTrue(compu_method.is_valid_internal_value(3))
         self.assertTrue(compu_method.is_valid_internal_value(15))
@@ -85,9 +85,9 @@ class TestLinearCompuMethod(unittest.TestCase):
         self.assertFalse(compu_method.is_valid_internal_value(16))
 
         self.assertTrue(compu_method.is_valid_physical_value(-74))
-        self.assertTrue(compu_method.is_valid_physical_value(-10))
+        self.assertTrue(compu_method.is_valid_physical_value(-14))
         self.assertFalse(compu_method.is_valid_physical_value(-75))
-        self.assertFalse(compu_method.is_valid_physical_value(-9))
+        self.assertFalse(compu_method.is_valid_physical_value(-13))
 
 
 if __name__ == '__main__':

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -6,13 +6,15 @@ from odxtools.endofpdufield import EndOfPduField
 from odxtools.dataobjectproperty import DataObjectProperty, DiagnosticTroubleCode, DtcDop
 from odxtools.compumethods import IdenticalCompuMethod, LinearCompuMethod
 from odxtools.message import Message
-import unittest
-
 from odxtools.diagcodedtypes import StandardLengthType
 from odxtools.parameters import CodedConstParameter, MatchingRequestParameter, ValueParameter
+from odxtools.physicaltype import PhysicalType
 from odxtools.structures import Request, Response, Structure
 from odxtools.service import DiagService
 from odxtools.diaglayer import DiagLayer
+from odxtools.odxtypes import DataType
+
+import unittest
 
 
 class TestIdentifyingService(unittest.TestCase):
@@ -92,7 +94,7 @@ class TestDecoding(unittest.TestCase):
         expected_message = Message(coded_message, service, req, param_dict={"SID": 0x7d,
                                                                             "coded_const_parameter_2": 0xab})
         decoded_message = diag_layer.decode(coded_message)[0]
-        
+
         self.assertEqual(expected_message.coded_message,
                          decoded_message.coded_message)
         self.assertEqual(expected_message.service, decoded_message.service)
@@ -154,7 +156,7 @@ class TestDecoding(unittest.TestCase):
         dop = DataObjectProperty("dop.id",
                                  "dop_sn",
                                  diag_coded_type_4,
-                                 physical_data_type="A_UINT32",
+                                 physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
         id_lookup.update({dop.id: dop})
 
@@ -209,7 +211,7 @@ class TestDecoding(unittest.TestCase):
         dop = DataObjectProperty("dop.id",
                                  "dop_sn",
                                  diag_coded_type_4,
-                                 physical_data_type="A_UINT32",
+                                 physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
         id_lookup.update({dop.id: dop})
 
@@ -257,7 +259,8 @@ class TestDecoding(unittest.TestCase):
                          decoded_message.coded_message)
         self.assertEqual(expected_message.service, decoded_message.service)
         self.assertEqual(expected_message.structure, decoded_message.structure)
-        self.assertEqual(expected_message.param_dict, decoded_message.param_dict)
+        self.assertEqual(expected_message.param_dict,
+                         decoded_message.param_dict)
 
     def test_decode_request_linear_compu_method(self):
         id_lookup = {}
@@ -267,7 +270,7 @@ class TestDecoding(unittest.TestCase):
         dop = DataObjectProperty("linear.dop.id",
                                  "linear.dop.sn",
                                  diag_coded_type,
-                                 physical_data_type="A_UINT32",
+                                 physical_type=PhysicalType(DataType.A_UINT32),
                                  compu_method=compu_method)
         id_lookup[dop.id] = dop
         req_param1 = CodedConstParameter("SID",
@@ -380,7 +383,7 @@ class TestDecoding(unittest.TestCase):
         dop = DtcDop("dtc.dop.id",
                      "dtc_dop_sn",
                      diag_coded_type,
-                     physical_data_type="A_UINT32",
+                     physical_type=PhysicalType(DataType.A_UINT32),
                      compu_method=compu_method,
                      dtcs=dtcs,
                      is_visible=True)

--- a/tests/test_diag_coded_types.py
+++ b/tests/test_diag_coded_types.py
@@ -8,6 +8,7 @@ from odxtools.parameters import LengthKeyParameter, CodedConstParameter, ValuePa
 from odxtools.decodestate import ParameterValuePair
 
 from odxtools.diaglayer import DiagLayer
+from odxtools.physicaltype import PhysicalType
 from odxtools.structures import Request
 
 from odxtools.compumethods import IdenticalCompuMethod, LinearCompuMethod
@@ -113,7 +114,7 @@ class TestLeadingLengthInfoType(unittest.TestCase):
                 id="BV.dummy_DL.DOP.certificateClient",
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["certificateClient"],
-                physical_data_type="A_BYTEFIELD",
+                physical_type=PhysicalType("A_BYTEFIELD"),
                 compu_method=compumethods["bytes_passthrough"]),
         }
 
@@ -255,7 +256,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                 id="BV.dummy_DL.DOP.uint8_times_8",
                 short_name="uint8_times_8",
                 diag_coded_type=diagcodedtypes["uint8"],
-                physical_data_type="A_UINT32",
+                physical_type=PhysicalType("A_UINT32"),
                 compu_method=compumethods["multiply_with_8"]),
 
             "certificateClient":
@@ -263,7 +264,7 @@ class TestParamLengthInfoType(unittest.TestCase):
                 id="BV.dummy_DL.DOP.certificateClient",
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["length_key_ref_to_lengthOfCertificateClient"],
-                physical_data_type="A_UINT32",
+                physical_type=PhysicalType("A_UINT32"),
                 compu_method=compumethods["uint_passthrough"]),
         }
 
@@ -466,7 +467,7 @@ class TestMinMaxLengthType(unittest.TestCase):
                 id="BV.dummy_DL.DOP.certificateClient",
                 short_name="certificateClient",
                 diag_coded_type=diagcodedtypes["certificateClient"],
-                physical_data_type="A_BYTEFIELD",
+                physical_type=PhysicalType("A_BYTEFIELD"),
                 compu_method=compumethods["bytes_passthrough"]),
         }
 

--- a/tests/test_diag_data_dictionary_spec.py
+++ b/tests/test_diag_data_dictionary_spec.py
@@ -7,6 +7,7 @@ from odxtools.compumethods import IdenticalCompuMethod
 from odxtools.diagcodedtypes import StandardLengthType
 from odxtools.dataobjectproperty import DataObjectProperty, DiagnosticTroubleCode, DtcDop
 from odxtools.diagdatadictionaryspec import *
+from odxtools.physicaltype import PhysicalType
 
 
 class TestDiagDataDictionarySpec(unittest.TestCase):
@@ -16,7 +17,7 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
 
         dtc_dop = DtcDop("DOP.dtc_dop", "dtc_dop",
                          diag_coded_type=uint_type,
-                         physical_data_type="A_UINT32",
+                         physical_type=PhysicalType("A_UINT32"),
                          compu_method=ident_compu_methud,
                          dtcs=[DiagnosticTroubleCode(
                              "DOP.dtc_dop.DTC.X10",
@@ -29,13 +30,13 @@ class TestDiagDataDictionarySpec(unittest.TestCase):
         dop_1 = DataObjectProperty("DOP.the_dop",
                                    "the_dop",
                                    diag_coded_type=uint_type,
-                                   physical_data_type="A_UINT32",
+                                   physical_type=PhysicalType("A_UINT32"),
                                    compu_method=ident_compu_methud)
 
         dop_2 = DataObjectProperty("DOP.another_dop",
                                    "another_dop",
                                    diag_coded_type=uint_type,
-                                   physical_data_type="A_UINT32",
+                                   physical_type=PhysicalType("A_UINT32"),
                                    compu_method=ident_compu_methud)
 
         ddds = DiagDataDictionarySpec(dtc_dops=[dtc_dop],

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -8,6 +8,7 @@ from odxtools.dataobjectproperty import DataObjectProperty
 from odxtools.compumethods import LinearCompuMethod
 from odxtools.diagcodedtypes import StandardLengthType
 from odxtools.parameters import CodedConstParameter, ValueParameter
+from odxtools.physicaltype import PhysicalType
 from odxtools.structures import Request
 
 class TestEncodeRequest(unittest.TestCase):
@@ -34,7 +35,7 @@ class TestEncodeRequest(unittest.TestCase):
         # This CompuMethod represents the linear function: decode(x) = 2*x + 8 and encode(x) = (x-8)/2
         compu_method = LinearCompuMethod(8, 2, "A_UINT32", "A_UINT32")
         dop = DataObjectProperty("dop-id", "example dop", diag_coded_type,
-                                 physical_data_type="A_UINT32", compu_method=compu_method)
+                                 physical_type=PhysicalType("A_UINT32"), compu_method=compu_method)
         param1 = ValueParameter("linear_value_parameter", dop=dop)
         req = Request("request_id", "request_sn", [param1])
 

--- a/tests/test_odxtypes.py
+++ b/tests/test_odxtypes.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022 MBition GmbH
+
+import unittest
+from odxtools.odxtypes import DataType
+
+
+class TestDataType(unittest.TestCase):
+
+    def test_cast_string(self):
+        self.assertTrue(DataType.A_UINT32 == DataType("A_UINT32"))
+
+    def test_cast(self):
+        self.assertTrue(DataType.A_UINT32.cast("12") == 12)
+        self.assertTrue(DataType.A_FLOAT64.cast("3.14") == 3.14)
+        self.assertTrue(DataType.A_INT32.cast(3.14) == 3)
+
+        self.assertRaises(TypeError, DataType.A_BYTEFIELD.cast, "12")
+
+        self.assertTrue(DataType.A_UINT32.cast_string("12") == 12)
+        self.assertTrue(DataType.A_BYTEFIELD.cast_string("12")
+                        == bytes([0x12]))
+
+    def test_python_types(self):
+        self.assertTrue(DataType.A_UINT32.as_python_type() == int)
+        self.assertTrue(DataType.A_INT32.as_python_type() == int)
+        self.assertTrue(DataType.A_FLOAT32.as_python_type() == float)
+        self.assertTrue(DataType.A_FLOAT64.as_python_type() == float)
+        self.assertTrue(DataType.A_BYTEFIELD.as_python_type() == bytearray)
+        self.assertTrue(DataType.A_UNICODE2STRING.as_python_type() == str)
+        self.assertTrue(DataType.A_UTF8STRING.as_python_type() == str)
+        self.assertTrue(DataType.A_ASCIISTRING.as_python_type() == str)
+
+    def test_isinstance(self):
+        self.assertTrue(DataType.A_ASCIISTRING.isinstance("123"))
+        self.assertTrue(DataType.A_BYTEFIELD.isinstance(bytes([0x12, 0x34])))
+        self.assertTrue(DataType.A_UINT32.isinstance(123))
+        self.assertTrue(DataType.A_FLOAT32.isinstance(123.456))
+        # We allow integers as float values
+        self.assertTrue(DataType.A_FLOAT32.isinstance(123))
+
+        self.assertFalse(DataType.A_UINT32.isinstance(bytes([0x12])))
+        self.assertFalse(DataType.A_BYTEFIELD.isinstance([0x12]))
+        self.assertFalse(DataType.A_BYTEFIELD.isinstance(0x12))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_unit_spec.py
+++ b/tests/test_unit_spec.py
@@ -3,6 +3,7 @@
 
 import unittest
 from xml.etree import ElementTree
+from odxtools.physicaltype import PhysicalType
 
 from odxtools.units import read_unit_spec_from_odx, Unit, UnitSpec, PhysicalDimension
 
@@ -83,7 +84,7 @@ class TestUnitSpec(unittest.TestCase):
             id="dop_id",
             short_name="dop_sn",
             diag_coded_type=dct,
-            physical_data_type="A_UINT32",
+            physical_type=PhysicalType("A_UINT32"),
             compu_method=IdenticalCompuMethod("A_UINT32", "A_UINT32"),
             unit_ref=unit.id
         )


### PR DESCRIPTION
This PR does 3 main things (where the first two cause a lot of commit noise):

* Add an enum for data types, i.e., magical strings like `"A_UINT32"` are replaced by `DataType.A_UINT32`
  * The enum also offers methods to `cast` values, so the dicts `ODX_TYPE_PARSER` and `ODX_TYPE_TO_PYTHON_TYPE` shouldn't be used anymore
* Add a class `PhysicalType` for `PHYSICAL-TYPE` elements.
  Previously the physical type of a DOP was just represented by the string for the data type (e.g. `dop.physical_data_type == "A_UINT32"`). Besides the data type, odxfiles can also specify a display radix or precision in the physical type.

This does make accessing the data type a bit more complex, i.e., the previous
```python
dop.physical_data_type
```
is now
```python
dop.physical_type.base_data_type.value
```

* Additionally, this PR fixes the computation of `LinearCompuMethod.physical_limit`s when the interval type of the internal limit is `OPEN` and the data type is an integer. In these cases, the physical limit now has the interval type `CLOSED` and only complies to physical values that map to valid internal values.

Katrin Bauer <[katrin.b.bauer@daimler.com](mailto:katrin.b.bauer@daimler.com)>, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)