### PR TITLE
Add relaxed output formatting option for find command,

### DIFF
--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -21,7 +21,7 @@ def format_desc(desc, ident=0):
     return desc
 
 
-def print_diagnostic_service(service: DiagService, print_params=False):
+def print_diagnostic_service(service: DiagService, print_params=False, allow_unknown_bit_lengths=False):
 
     print(f" {service.short_name} <ID: {service.id}>")
 
@@ -31,21 +31,25 @@ def print_diagnostic_service(service: DiagService, print_params=False):
 
     if print_params:
         print(f"  Message format of a request:")
-        service.request.print_message_format(indent=3)
+        service.request.print_message_format(
+            indent=3,
+            allow_unknown_lengths=allow_unknown_bit_lengths)
 
         print(
             f"  Number of positive responses: {len(service.positive_responses)}")
         if len(service.positive_responses) == 1:
             print(f"  Message format of a positive response:")
             service.positive_responses[0].print_message_format(
-                indent=3)
+                indent=3,
+                allow_unknown_lengths=allow_unknown_bit_lengths)
 
         print(
             f"  Number of negative responses: {len(service.negative_responses)}")
         if len(service.negative_responses) == 1:
             print(f"  Message format of a negative response:")
             service.negative_responses[0].print_message_format(
-                indent=3)
+                indent=3,
+                allow_unknown_lengths=allow_unknown_bit_lengths)
 
     if len(service.positive_responses) > 1 or len(service.negative_responses) > 1:
         # Does this ever happen?

--- a/odxtools/structures.py
+++ b/odxtools/structures.py
@@ -172,7 +172,7 @@ class BasicStructure(DopBase):
             if isinstance(p, ParameterWithDOP):
                 p.resolve_references(parent_dl, id_lookup)
 
-    def __message_format_lines(self):
+    def __message_format_lines(self, allow_unknown_lengths=False):
         # sort parameters
         sorted_params: list = list(self.parameters)  # copy list
         if all(p.byte_position is not None for p in self.parameters):
@@ -243,7 +243,7 @@ class BasicStructure(DopBase):
 
                         break
 
-                    elif not params[i].bit_length:
+                    elif not params[i].bit_length and not allow_unknown_lengths:
                         # The bit length is not set for the current
                         # parameter, i.e. it was either not specified
                         # or the parameter is of variable length and
@@ -252,9 +252,9 @@ class BasicStructure(DopBase):
                         error = True
                         break
                     else:
-                        breakpoint += params[i].bit_length
+                        breakpoint += params[i].bit_length or (allow_unknown_lengths and 8)
                         name = params[i].short_name + \
-                            f" ({params[i].bit_length} bits)"
+                            f" ({params[i].bit_length or 'Unknown'} bits)"
                         next_line += "| " + name
 
                     i += 1
@@ -296,12 +296,12 @@ class BasicStructure(DopBase):
         else:
             return None
 
-    def print_message_format(self, indent: int = 5):
+    def print_message_format(self, indent: int = 5, allow_unknown_lengths=False):
         """
         Print a description of the message format to `stdout`.
         """
 
-        message_as_lines = self.__message_format_lines()
+        message_as_lines = self.__message_format_lines(allow_unknown_lengths=allow_unknown_lengths)
         if message_as_lines is not None:
             print(f"{indent * ' '}" +
                   f"\n{indent * ' '}".join(message_as_lines))


### PR DESCRIPTION
Adds a relaxed output formatting option for the find command, to
allow unknown bit-length fields to be rendered as ascii, and
improve the output of decoded messages.

--

Florian Roks \<florian.roks@daimler.com\>, Daimler TSS GmbH
[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)
