### PR TITLE
Fix static typing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,19 +3,15 @@ name: Tests
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  test:
+  unittest-and-lint:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install -r requirements.txt
-        python3 -m pip install coveralls
+        python3 -m pip install coveralls mypy
     - name: Create somersault.pdx
       run: |
         export PYTHONPATH=$PYTHONPATH:$PWD
@@ -25,3 +21,8 @@ jobs:
       run: |
         export PYTHONPATH=$PYTHONPATH:$PWD
         python3 -m unittest tests/*.py
+    - name: Static type checking with mypy
+      run: |
+        python3 -m mypy --ignore-missing-imports --python-version 3.8 odxtools
+        python3 -m mypy --ignore-missing-imports --python-version 3.9 odxtools
+        python3 -m mypy --ignore-missing-imports --python-version 3.10 odxtools

--- a/odxtools/audience.py
+++ b/odxtools/audience.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 from dataclasses import dataclass, field
+from typing import Optional
 from odxtools.utils import read_description_from_odx
 
 
@@ -37,8 +38,8 @@ class AdditionalAudience:
     """
     id: str
     short_name: str
-    long_name: str = None
-    description: str = None
+    long_name: Optional[str] = None
+    description: Optional[str] = None
 
 
 def read_audience_from_odx(et_element):

--- a/odxtools/cli/_print_utils.py
+++ b/odxtools/cli/_print_utils.py
@@ -30,6 +30,10 @@ def print_diagnostic_service(service: DiagService, print_params=False, allow_unk
         print(f"  Service description: " + desc)
 
     if print_params:
+        assert service.request is not None
+        assert service.positive_responses is not None
+        assert service.negative_responses is not None
+
         print(f"  Message format of a request:")
         service.request.print_message_format(
             indent=3,
@@ -38,6 +42,8 @@ def print_diagnostic_service(service: DiagService, print_params=False, allow_unk
         print(
             f"  Number of positive responses: {len(service.positive_responses)}")
         if len(service.positive_responses) == 1:
+            assert service.positive_responses[0] is not None
+
             print(f"  Message format of a positive response:")
             service.positive_responses[0].print_message_format(
                 indent=3,
@@ -46,12 +52,15 @@ def print_diagnostic_service(service: DiagService, print_params=False, allow_unk
         print(
             f"  Number of negative responses: {len(service.negative_responses)}")
         if len(service.negative_responses) == 1:
+            assert service.negative_responses[0] is not None
+
             print(f"  Message format of a negative response:")
             service.negative_responses[0].print_message_format(
                 indent=3,
                 allow_unknown_lengths=allow_unknown_bit_lengths)
 
-    if len(service.positive_responses) > 1 or len(service.negative_responses) > 1:
+    if ((service.positive_responses and len(service.positive_responses) > 1)
+            or (service.negative_responses and len(service.negative_responses) > 1)):
         # Does this ever happen?
         raise NotImplementedError(
             f"The diagnostic service {service.id} offers more than one response!")

--- a/odxtools/cli/find.py
+++ b/odxtools/cli/find.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 import argparse
+from typing import Dict, List
 
 from ._print_utils import print_diagnostic_service
 from ..database import Database
@@ -39,7 +40,7 @@ def print_summary(odxdb: Database,
     ecu_names = ecu_variants if ecu_variants else [
         ecu.short_name for ecu in odxdb.ecus
     ]
-    services = {}
+    services: Dict[DiagService, List[str]] = {}
     for ecu_name in ecu_names:
         ecu = odxdb.ecus[ecu_name]
         if not ecu:

--- a/odxtools/cli/list.py
+++ b/odxtools/cli/list.py
@@ -43,21 +43,21 @@ def print_summary(odxdb: Database,
         print(
             f" num services: {len(service_sns)}, num DOPs: {len(data_object_properties)}, num communication parameters: {len(com_params)}."
         )
-        
+
         if dl.description:
             desc = format_desc(dl.description, ident=2)
             print(f" Description: " + desc)
 
         if print_services and len(service_sns) > 0:
-            services = [dl.services[service_sn] for service_sn in service_sns]
-            services = list(filter(service_filter, services))
+            all_services = [dl.services[service_sn] for service_sn in service_sns]
+            services = [s for s in all_services
+                        if s is not None and service_filter(s)]
             if len(services) > 0:
                 print(
                     f"The services of the {dl.variant_type} '{dl.short_name}' are: ")
                 for service in services:
-                    if service_filter(service):
-                        print_diagnostic_service(
-                            service, print_params=print_params)
+                    print_diagnostic_service(
+                        service, print_params=print_params)
 
         if print_dops and len(data_object_properties) > 0:
             print(f"The DOPs of the {dl.variant_type} '{dl.short_name}' are: ")

--- a/odxtools/database.py
+++ b/odxtools/database.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 
+from typing import Any, Dict
 from xml.etree import ElementTree
 from itertools import chain
 from zipfile import ZipFile
@@ -20,7 +21,7 @@ class Database:
                  odx_d_file_name: str = None,
                  enable_candela_workarounds: bool = True):
         self._diag_layer_containers = []
-        self._id_lookup = {}
+        self._id_lookup: Dict[str, Any] = {}
         dlc_elements = []
 
         if pdx_zip is None and odx_d_file_name is None:

--- a/odxtools/dataobjectproperty.py
+++ b/odxtools/dataobjectproperty.py
@@ -33,16 +33,6 @@ class DopBase(abc.ABC):
         self.description = description
         self.is_visible = is_visible
 
-    @property
-    @abc.abstractclassmethod
-    def bit_length(self):
-        pass
-
-    @abc.abstractclassmethod
-    def convert_physical_to_internal(self, physical_value):
-        """Convert the physical value to the internal value."""
-        pass
-
     @abc.abstractclassmethod
     def convert_physical_to_bytes(self, physical_value, encode_state: EncodeState, bit_position: int) -> bytes:
         """Convert the physical value into bytes."""

--- a/odxtools/diagcodedtypes.py
+++ b/odxtools/diagcodedtypes.py
@@ -139,9 +139,11 @@ class DiagCodedType(abc.ABC):
         if self.base_data_type == DataType.A_BYTEFIELD:
             byte_length = len(internal_value)
         elif self.base_data_type in [DataType.A_ASCIISTRING, DataType.A_UTF8STRING]:
+            assert isinstance(internal_value, str)
             # TODO: Handle different encodings
             byte_length = len(bytes(internal_value, "utf-8"))
         elif self.base_data_type == DataType.A_UNICODE2STRING:
+            assert isinstance(internal_value, str)
             byte_length = len(bytes(internal_value, "utf-16-le"))
             assert byte_length % 2 == 0, (f"The bit length of A_UNICODE2STRING must"
                                           f" be a multiple of 16 but is {8*byte_length}")

--- a/odxtools/diaglayer.py
+++ b/odxtools/diaglayer.py
@@ -135,9 +135,12 @@ class DiagLayer:
         self.functional_classes = functional_classes
 
         # Properties that include inherited objects
-        self._services = []
-        self._communication_parameters = []
-        self._data_object_properties = []
+        self._services: NamedItemList[DiagService]\
+            = NamedItemList(lambda s: s.short_name, [])
+        self._communication_parameters: NamedItemList[CommunicationParameterRef]\
+            = NamedItemList(lambda s: s.id_ref, [])
+        self._data_object_properties: NamedItemList[DopBase]\
+            = NamedItemList(lambda s: s.short_name, [])
 
         if id_lookup is not None:
             self.finalize_init(id_lookup)
@@ -371,7 +374,7 @@ class DiagLayer:
                 pass
         if len(decoded_messages) == 0:
             raise DecodeError(
-                f"None of the services {possible_services} could parse {message}.")
+                f"None of the services {possible_services} could parse {message.hex()}.")
         return decoded_messages
 
     def decode_response(self, response: Union[bytes, bytearray], request: Union[bytes, bytearray, Message]) -> Iterable[Message]:
@@ -396,7 +399,7 @@ class DiagLayer:
                 pass
         if len(decoded_messages) == 0:
             raise DecodeError(
-                f"None of the services {possible_services} could parse {response}.")
+                f"None of the services {possible_services} could parse {response.hex()}.")
         return decoded_messages
 
     def get_receive_id(self):

--- a/odxtools/encodestate.py
+++ b/odxtools/encodestate.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 MBition GmbH
 
-from typing import Any, Dict, NamedTuple, Union
+from typing import Any, Dict, NamedTuple, Optional, Union
 
 
 class EncodeState(NamedTuple):
@@ -22,7 +22,7 @@ class EncodeState(NamedTuple):
     # a mapping from short name to value for each parameter
     parameter_values: Dict[str, Any]
     # For encoding a response: request that triggered the response
-    triggering_request: Union[bytes, bytearray] = None
+    triggering_request: Optional[Union[bytes, bytearray]] = None
     # Mapping from IDs to bit lengths (specified by LengthKeyParameters)
     length_keys: Dict[str, int] = {}
     # Flag whether the parameter is the last on the PDU (needed for MinMaxLengthType)

--- a/odxtools/functionalclass.py
+++ b/odxtools/functionalclass.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 from dataclasses import dataclass
+from typing import Optional
 from odxtools.utils import read_description_from_odx
 
 
@@ -12,8 +13,8 @@ class FunctionalClass:
     """
     id: str
     short_name: str
-    long_name: str = None
-    description: str = None
+    long_name: Optional[str] = None
+    description: Optional[str] = None
 
 
 def read_functional_class_from_odx(et_element):

--- a/odxtools/odxtypes.py
+++ b/odxtools/odxtypes.py
@@ -2,15 +2,17 @@
 # Copyright (c) 2022 MBition GmbH
 
 from enum import Enum
-from typing import Any, Union
+from typing import Any, Callable, Dict, Literal, Type, Union
 
 
 def bytefield_to_bytearray(bytefield: str) -> bytearray:
     bytes_string = [bytefield[i:i+2] for i in range(0, len(bytefield), 2)]
     return bytearray(map(lambda x: int(x, 16), bytes_string))
 
+PythonType = Union[str, int, float, bytearray]
+LiteralPythonType = Type[Union[str, int, float, bytearray]]
 
-_ODX_TYPE_PARSER = {
+_ODX_TYPE_PARSER: Dict[str, Callable[[str], PythonType]] = {
     "A_INT32": int,
     "A_UINT32": int,
     "A_FLOAT32": float,
@@ -22,7 +24,7 @@ _ODX_TYPE_PARSER = {
     "A_UTF8STRING": str
 }
 
-_ODX_TYPE_TO_PYTHON_TYPE = {
+_ODX_TYPE_TO_PYTHON_TYPE: Dict[str, LiteralPythonType] = {
     "A_INT32": int,
     "A_UINT32": int,
     "A_FLOAT32": float,
@@ -33,6 +35,7 @@ _ODX_TYPE_TO_PYTHON_TYPE = {
     "A_ASCIISTRING": str,
     "A_UTF8STRING": str
 }
+
 
 class DataType(Enum):
     """Types for the physical and internal value.

--- a/odxtools/uds.py
+++ b/odxtools/uds.py
@@ -7,7 +7,7 @@ from typing import Union
 
 import odxtools.obd as obd
 
-class SID(IntEnum):
+class UDSSID(IntEnum):
     """The service IDs standardized by UDS.
 
     For additional information, see https://en.wikipedia.org/wiki/Unified_Diagnostic_Services
@@ -48,7 +48,7 @@ class SID(IntEnum):
     # 0xBA..0xBE: Reserved for ECU specific services
 
 # add the OBD SIDs to the ones from UDS
-SID = IntEnum('UdsSID', [(i.name, i.value) for i in chain(obd.SID, SID)])
+SID = IntEnum('UdsSID', ((i.name, i.value) for i in chain(obd.SID, UDSSID)))  # type: ignore
 
 class NegativeResponseCodes(IntEnum):
     """The standardized negative response codes of UDS.
@@ -90,8 +90,8 @@ def positive_response_id(service_id: int) -> int:
 NegativeResponseId = 0x7f
 def negative_response_id(service_id: int) -> int:
     """Given a service ID of a request, return the corresponding SID for a negative response"""
-    assert service_id != 0x7f - 0x40
-    return UdsNegativeResponseId
+    assert service_id != 0x7f - 0x40  # TODO: What is this assert supposed to do?
+    return NegativeResponseId
 
 def is_reponse_pending(telegram_payload: Union[bytes, bytearray], request_sid: int = None) -> bool:
     # "response pending" responses exhibit at least three bytes
@@ -102,7 +102,7 @@ def is_reponse_pending(telegram_payload: Union[bytes, bytearray], request_sid: i
     rq_sid = telegram_payload[1]
     resp_code = telegram_payload[2]
 
-    # "response pending" answers are alway negative
+    # "response pending" answers are always negative
     if sid != NegativeResponseId:
         return False
 

--- a/odxtools/units.py
+++ b/odxtools/units.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 MBition GmbH
 
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from .nameditemlist import NamedItemList
 from .utils import read_description_from_odx
@@ -168,10 +168,13 @@ class UnitSpec:
 
     The following odx elements are not internalized: ADMIN-DATA, SDGS
     """
-    unit_groups: NamedItemList[UnitGroup] = field(default_factory=list)
-    units: NamedItemList[Unit] = field(default_factory=list)
-    physical_dimensions: NamedItemList[PhysicalDimension] = field(
-        default_factory=list)
+    # TODO (?): Why are there type errors...
+    unit_groups: Union[NamedItemList[UnitGroup],
+                       List[UnitGroup]] = field(default_factory=list)  # type: ignore
+    units: Union[NamedItemList[Unit], List[Unit]] = field(
+        default_factory=list)  # type: ignore
+    physical_dimensions: Union[NamedItemList[PhysicalDimension],
+                               List[PhysicalDimension]] = field(default_factory=list)  # type: ignore
 
     def __post_init__(self):
         self.unit_groups = NamedItemList(lambda x: x.short_name,


### PR DESCRIPTION
This PR attempts to make the static type checker [`mypy`](https://mypy.readthedocs.io/en/stable/introduction.html) happy.

There's some errors that need to be escaped with `# type: ignore`, because I either couldn't rewrite the code in a type-safe manner or didn't understand why `mypy` had a problem to begin with...

You can run `mypy` with
```
$ mypy --ignore-missing-imports odxtools
Success: no issues found in 42 source files
```

Katrin Bauer <[katrin.b.bauer@daimler.com](mailto:katrin.b.bauer@daimler.com)>, on behalf of [MBition GmbH](https://mbition.io/).
[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)